### PR TITLE
Feature/firsenkova alina planning shopping placeholder

### DIFF
--- a/ShoppingList27/Extensions/Font+Extension.swift
+++ b/ShoppingList27/Extensions/Font+Extension.swift
@@ -1,0 +1,22 @@
+//
+//  Font+Extension.swift
+//  ShoppingList27
+//
+//  Created by Алина on 04.09.2025.
+//
+
+import SwiftUI
+
+/// Расширение для удобного использования кастомного шрифта.
+/// Позволяет использовать "Font.title3Medium" вместо повторного указания размера и веса.
+/// Список можно дополнять по мере необходимости другими шрифтами.
+extension Font {
+    
+    static var title3Medium: Font {
+        Font.system(size: 20, weight: .medium)
+    }
+    
+    static var regular17: Font {
+        Font.system(size: 17, weight: .regular)
+    }
+}

--- a/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderVM.swift
+++ b/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderVM.swift
@@ -1,0 +1,26 @@
+//
+//  PlanningShoppingPlaceholderVM.swift
+//  ShoppingList27
+//
+//  Created by Алина on 04.09.2025.
+//
+
+import SwiftUI
+
+// MARK: - ViewModel
+
+/// ViewModel для плейсхолдера экрана "Давайте спланируем покупки".
+/// Содержит статические данные: заголовок, картинку и текстовые сообщения.
+@MainActor
+final class PlanningShoppingPlaceholderVM: ObservableObject {
+    
+    private enum Constants {
+        static let imageName = "createList"
+        static let mainText = "Давайте спланируем покупки!"
+        static let subText = "Создайте свой первый список"
+    }
+    
+    @Published var imageName: String = Constants.imageName
+    @Published var mainText: String = Constants.mainText
+    @Published var subText: String = Constants.subText
+}

--- a/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderView.swift
+++ b/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderView.swift
@@ -1,0 +1,70 @@
+//
+//  PlanningShoppingPlaceholderView.swift
+//  ShoppingList27
+//
+//  Created by Алина on 04.09.2025.
+//
+
+import SwiftUI
+
+
+/// Плейсхолдер экрана "Давайте спланируем покупки".
+/// Отображает картинку и текстовые подсказки, по центру экрана.
+struct PlanningShoppingPlaceholderView: View {
+    
+    @StateObject private var viewModel = PlanningShoppingPlaceholderVM()
+    
+    var body: some View {
+        VStack(spacing: 28) {
+            imageContent
+            textContent
+        }
+        .padding(.top, 190)
+        .padding(.bottom, 232)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+    
+    private var imageContent: some View {
+        Image(viewModel.imageName)
+            .resizable()
+            .scaledToFill()
+            .clipped()
+            .background(Color.clear)
+            .padding(.horizontal, 49)
+    }
+    
+    private var textContent: some View {
+        VStack(spacing: 4) {
+            headlineText
+            supportingText
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .background(Color.clear)
+    }
+    
+    private var headlineText: some View {
+        Text(viewModel.mainText)
+            .font(.title3Medium)
+            .foregroundColor(.grey80)
+            .multilineTextAlignment(.center)
+            .lineLimit(1)
+            .background(Color.clear)
+    }
+    
+    private var supportingText: some View {
+        Text(viewModel.subText)
+            .font(.regular17)
+            .foregroundColor(.grey80)
+            .multilineTextAlignment(.center)
+            .lineLimit(1)
+            .background(Color.clear)
+    }
+}
+
+// MARK: - Preview
+struct PlanningShoppingPlaceholderViewPreviews: PreviewProvider {
+    static var previews: some View {
+        PlanningShoppingPlaceholderView()
+    }
+}

--- a/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderView.swift
+++ b/ShoppingList27/Screens/Components/Placeholders/PlanningShopping/PlanningShoppingPlaceholderView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 
-
 /// Плейсхолдер экрана "Давайте спланируем покупки".
 /// Отображает картинку и текстовые подсказки, по центру экрана.
 struct PlanningShoppingPlaceholderView: View {


### PR DESCRIPTION
## Что сделано
- Added ViewModel PlanningShoppingPlaceholderVM
- Added PlanningShoppingPlaceholderView screen placeholder
- Added Font extension with custom styles (title3Medium, regular17)

## Скриншоты (если UI)

<img width="332" height="684" alt="Снимок экрана 2025-09-05 в 09 50 30" src="https://github.com/user-attachments/assets/a5c88974-dda2-4fc9-8c4c-8ab63caf475f" />


## Чеклист
- [ ] Код собирается и запускается в Xcode
- [ ] Нет ворнингов
- [ ] Поддержка превью в разных стейтах (если UI)

## Ссылка на задачу/issue

[Issue #9](https://github.com/FactoryiOS/ShoppingList27/issues/9)